### PR TITLE
docs: add Bluesky link to Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Sifa is built by [Singi Labs](https://singi.dev), alongside [Barazo](https://bar
 ## Community
 
 - **Website:** [sifa.id](https://sifa.id)
+- **Bluesky:** [@sifa.id](https://bsky.app/profile/sifa.id)
 - **Issues:** [Report bugs or request features](https://github.com/singi-labs/sifa-workspace/issues)
 
 ---


### PR DESCRIPTION
## Summary

- Follow-up to #170 which removed the GitHub Discussions link.
- Adds the product Bluesky handle ([@sifa.id](https://bsky.app/profile/sifa.id)) to the Community section so contributors have a clear informal channel.
- Part of an org-wide sweep aligning all 14 repos' Community sections.

## Test plan

- [x] Visual review of rendered README
- [x] Verify Bluesky link resolves