### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you find a security or privacy vulnerability in Sifa (sifa.id or any Sifa service), report it privately. **Email [security@sifa.id](mailto:security@sifa.id).**
+
+Do **not** open a public GitHub issue and do **not** post it on the public feedback board — a public report can expose the issue before it is fixed.
+
+Please include:
+
+- What the vulnerability is and where you found it (URL, endpoint, or repo).
+- Steps to reproduce it.
+- What an attacker could do with it.
+- Any logs, requests, or screenshots that help — but redact your own credentials, tokens, and personal data first.
+
+## What to expect
+
+Sifa is in alpha, run by a small team. We will acknowledge your report as soon as we can, keep you updated while we investigate, and let you know when it is resolved. We handle every report in good faith and will not pursue action against researchers who report in good faith and avoid privacy violations, data destruction, or service disruption while testing.
+
+## Scope
+
+In scope: sifa.id, the Sifa AppView and API, and the public Sifa packages (sifa-sdk, sifa-lexicons, sifa-page-renderer, sifa-page).
+
+Out of scope: third-party services Sifa builds on (the AT Protocol network, individual PDS hosts, userinput.app). Report those to their own maintainers.


### PR DESCRIPTION
Adds a `SECURITY.md` so vulnerability reports have a private path.

Reports go to security@sifa.id (an existing catch-all address) instead of a public GitHub issue or the public feedback board, so an issue is not exposed before it is fixed. The file also lists what to include in a report and which repos and services are in and out of scope.

Part of consolidating public feedback channels: a private security path is a prerequisite before pointing the site's "Report an issue" links at a public board.
